### PR TITLE
gboards/gergoplex set IGNORE_MOD_TAP_INTERRUPT

### DIFF
--- a/keyboards/gboards/gergoplex/config.h
+++ b/keyboards/gboards/gergoplex/config.h
@@ -43,6 +43,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MATRIX_ROW_PINS { F6, F5, F4, F1 }
 #define MATRIX_COL_PINS { B1, B2, B3, D2, D3 }
 #define UNUSED_PINS
+#define IGNORE_MOD_TAP_INTERRUPT
 
 #define IS_COMMAND() (get_mods() == (MOD_BIT(KC_LCTL) | MOD_BIT(KC_RCTL)) || get_mods() == (MOD_BIT(KC_LSFT) | MOD_BIT(KC_RSFT)))
 


### PR DESCRIPTION
This solves my issue was with hold-modifier keys such as `KC_CTL_A`. This was also originally set in @germ's repo
https://github.com/germ/qmk_firmware/blob/39c86e080dc04b68ee08387dcb5144c88cb44855/keyboards/gboards/k/gergoplex/config.h#L49

See https://beta.docs.qmk.fm/using-qmk/software-features/tap_hold#ignore-mod-tap-interrupt for more info
